### PR TITLE
Added two tests and some documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,20 @@ It consists of two components,
 ## Platform
 ```bred``` and ```xbred``` are tested on following platforms.
 
-* Ubuntu 14.04.2 LTS
+* Ubuntu 16.04.2 LTS
 
 ## Software dependencies
 
-* bash (Ubuntu - 4.3.11(1), Raspbian - 4.2.37(1))
+ * bash (Ubuntu - 4.3.11(1), Raspbian - 4.2.37(1))
  * bash needs to be a login shell of the user who executes ```bred``` and ```xbred```
-* Other Unix tools
+ * Other Unix tools
  * coreutils 
- * netcat-traditional (nc command. It must support listen mode)
+ * **netcat-traditional**
+     * netcat-openbsd provides the nc command on many dristributions by default which is not good.
+     * It also must support listen mode.
  * pv
- * gawk
+ * gawk or any awk implementation provides ```awk```
+     * mawk is considered faster than gawk in many cases
  * openssh-client
  * openssh-server
  * rsync
@@ -33,14 +36,16 @@ It consists of two components,
 
 * A unix user to execute ```bred``` and ```xbred```.
  * Currently only one user per environment can user ```bred``` and ```xbred```.
-
 * Login shell
-
 * Directories
 
-
 # Installation
-## Setting up an environment
+## Setting up an environment (on each machine)
+
+* **Make sure all tests pass before the actual usage!**
+* If something breaks down try cleaning up the environment first:
+    * ```killall awk; killall nc; rm -rf [BRED_WORKDIR]/ && mkdir -p [BRED_WORKDIR]/{fs,jm,sort}```
+* In case of problems try geing more information with ```export XBRED_DEBUG="on"```
 
 ## Build a utility program: ```brp```
 Build a utility program ```brp``` by running make command in ```utils``` directory.
@@ -54,6 +59,7 @@ Build a utility program ```brp``` by running make command in ```utils``` directo
 
 
 ## Place files somewhere handy in your PATH
+**Should work with non-interactive shell usage as well, where .bashrc is not parsed!**
 Recommended directory structure is shown below.
 Make sure each of them has a correct permission (shown in parentheses)
 
@@ -62,7 +68,7 @@ Make sure each of them has a correct permission (shown in parentheses)
     /usr/local
 	    bin/
 			bred.conf (644)
-		    bred (744)
+		        bred (744)
 			bred-core (644)
 			brp (755)
 			xbred (755)
@@ -142,6 +148,7 @@ Following is a 'word count' example written in ```xbred``` style.
     EOF
 
 ```
+**Run it with:** ```cat input.txt | ./word_count.xbred > output.txt```
 
 Refer to [XBRED](docs/XBRED.md) for more details.
 You can find more examples under [examples](examples/README.md) directory.

--- a/tests/br-test.sh
+++ b/tests/br-test.sh
@@ -56,6 +56,17 @@ function bredcheckenv_nc_is_installed() {
   fi
 }
 
+function bredcheckenv_nc_is_not_openbsd_version() {
+  if [ $1 == 'expected' ]; then
+    echo '0'
+  elif [ $1 == 'actual' ]; then
+    nc -h 2>&1 | grep "OpenBSD" | wc -l
+  else
+    echo "Invalid mode $1 is specified"
+    exit 1
+  fi
+}
+
 function bredcheckenv_nc_supports_listen_mode() {
   if [ $1 == 'expected' ]; then
     echo '2'
@@ -111,6 +122,23 @@ function bredcheckenv_loginshell_is_bash() {
     echo 'bash'
   elif [ $1 == 'actual' ]; then
     timeout 5 ssh localhost 'echo $0'
+  else
+    echo "Invalid mode $1 is specified"
+    exit 1
+  fi
+}
+
+####
+# Make sure bred is in the PATH even when .bashrc not executed because non-interactive shell
+#
+# Fix in case of fail:
+# 1. Make sure bredcheckenv_passwordless_ssh_is_ok is passing.
+# 2. Put bred for example under /usr/local/bin
+function bredcheckenv_bred_is_in_path_when_using_ssh_command_for_bredfs_write() {
+  if [ $1 == 'expected' ]; then
+    echo '1'
+  elif [ $1 == 'actual' ]; then
+    timeout 5 ssh localhost env PATH="$PATH" 'bred -h' 2>&1 | fgrep "bred. bashreduce enhanced." | wc -l 
   else
     echo "Invalid mode $1 is specified"
     exit 1


### PR DESCRIPTION
New tests:
    - Add check for _non-openbsd_ netcat
    - Add check for bred in $PATH when using non-interactive session

Documentation:
    - Tested on Ubuntu 16.04.2
    - Highlighted netcat-traditional as dependency
    - Mentioned mawk as a faster awk implementation
    - Mentioned running tests, purging workdir and stuck processes
    - Mentioned debug switch in a more significant place
    - Specified PATH for non-interactive shell usage (bredfs write)
    - Mentioned how to run the example code